### PR TITLE
Lógica de restart automático

### DIFF
--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -44,6 +44,7 @@ RemoteIO::RemoteIO()
   lastIP_index = -1;
   anchored = false;
   anchoring = false;
+  reconnect_counter = 0;
 }
 
 void RemoteIO::begin()
@@ -502,6 +503,7 @@ void RemoteIO::switchState()
     case DISCONNECTED:
       if (Connected)
       {
+        reconnect_counter = 0;
         //Serial.println("[DISCONNECTED] vai pro CONNECTED");
         next_state = CONNECTED;
       }
@@ -583,6 +585,8 @@ void RemoteIO::stateLogic()
       
       if (millis() - start_reconnect_time >= 60000)
       {
+        if (reconnect_counter >= 3) ESP.restart();
+        else reconnect_counter++;
         start_reconnect_time = millis();
         start_debounce_time = millis();
         nodeIotConnection(); 

--- a/src/ESP32RemoteIO.h
+++ b/src/ESP32RemoteIO.h
@@ -114,6 +114,7 @@ class RemoteIO
     bool anchored;
     bool anchoring;
     int lastIP_index;
+    int reconnect_counter;
 };
 
 #endif // ESP32RemoteIO_h


### PR DESCRIPTION
Quando desconectado do websocket, após 3 tentativas sem sucesso de reconexão, reinicia o dispositivo automaticamente.