### PR TITLE
Gerenciador de input - Leituras por interrupção

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+/src/main.cpp

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -12,6 +12,15 @@
 #include "ESP32RemoteIO.h";
 #include "index_html.h";
 
+typedef struct interrupt_data 
+{
+  RemoteIO* remoteio_pointer;
+  String ref_arg;
+} interrupt_data;
+
+DynamicJsonDocument post_data_queue(1024);
+unsigned long last_queue_sent_time = 0;
+
 RemoteIO::RemoteIO()
 {
   _appPort = 5000;
@@ -114,7 +123,7 @@ void RemoteIO::begin()
       ESP.restart();
   });
 
-  if (NVS_SSID.length() == 0 || NVS_PASSWORD.length() == 0 || NVS_COMPANYNAME.length() == 0 || NVS_DEVICEID.length() == 0 || NVS_MODEL.length() == 0)
+  if (NVS_SSID.length() == 0 || NVS_PASSWORD.length() == 0 || NVS_COMPANYNAME.length() == 0 || NVS_DEVICEID.length() == 0)
   {
     startAccessPoint();
   }
@@ -404,12 +413,23 @@ void RemoteIO::startAccessPoint()
   });
 }
 
+void RemoteIO::sendDataFromQueue()
+{
+  if (post_data_queue.size() >= 1)
+  {
+    last_queue_sent_time = millis();
+    espPOST(post_data_queue);
+    post_data_queue.clear();
+  }
+}
+
 void RemoteIO::loop()
 {
   ArduinoOTA.handle();
   switchState();
   stateLogic();
   checkResetting(5000); // millisegundos
+  sendDataFromQueue();
 }
 
 void RemoteIO::browseService(const char * service, const char * proto)
@@ -461,7 +481,7 @@ void RemoteIO::switchState()
     case INICIALIZATION:
       if ((WiFi.status() == WL_CONNECTED) && (Connected == true))
       {
-        //Serial.println("[INICIALIZATION] vai pro CONNECTED");
+        Serial.println("[INICIALIZATION] vai pro CONNECTED");
         next_state = CONNECTED;
       }
       else
@@ -711,7 +731,7 @@ void RemoteIO::nodeIotConnection()
     //Serial.print(".");
   }
   
-  //Serial.printf("[nodeIotConnection] WiFi Connected %s\n", WiFi.localIP().toString().c_str());
+  Serial.printf("[nodeIotConnection] WiFi Connected %s\n", WiFi.localIP().toString().c_str());
 
   appVerifyUrl.replace(" ", "%20");
   appLastDataUrl.replace(" ", "%20");
@@ -763,6 +783,27 @@ void RemoteIO::socketIOConnect()
   }
 }
 
+void IRAM_ATTR RemoteIO::interruptCallback(void* arg)
+{
+  interrupt_data* obj = (interrupt_data*)arg;
+  
+  if (post_data_queue.size() <= 10)
+  {
+    unsigned long reading_timestamp = millis();
+    int value = digitalRead(obj->remoteio_pointer->setIO[obj->ref_arg]["pin"].as<int>());
+
+    DynamicJsonDocument doc(75);
+    doc["ref"] = obj->ref_arg;
+    doc["value"] = value;
+    doc["timestamp"] = reading_timestamp;
+
+    obj->remoteio_pointer->setIO[obj->ref_arg]["value"] = value;
+    obj->remoteio_pointer->setIO[obj->ref_arg]["timestamp"] = reading_timestamp;
+
+    post_data_queue.add(doc);
+  }
+}
+
 void RemoteIO::tryAuthenticate()
 {
   WiFiClientSecure client;
@@ -782,14 +823,10 @@ void RemoteIO::tryAuthenticate()
   document["mac"] = WiFi.macAddress();
   document["ipAddress"] = WiFi.localIP().toString();
   document["settingsTimestamp"] = storedTimestamp;
-  if (model == "")
-  { 
-    document["model"] = "ESP_32";
-  }
-  else
-  { 
-    document["model"] = model;
-  }
+  
+  if (model == "") document["model"] = "ESP_32";
+  else document["model"] = model;
+  
   serializeJson(document, request);
 
   https.begin(client, appVerifyUrl);
@@ -826,37 +863,63 @@ void RemoteIO::tryAuthenticate()
     deviceConfig->end();
     token = document["token"].as<String>();
     extractIPAddress(document["serverAddr"].as<String>());
-    //Serial.println(document["serverAddr"].as<String>());
 
     for (size_t i = 0; i < document["gpio"].size(); i++)
     {
       String ref = document["gpio"][i]["ref"];
-
       int pin = document["gpio"][i]["pin"].as<int>();
       String type = document["gpio"][i]["type"];
+      String mode = document["gpio"][i]["mode"]; // modo de operação. Ex. p/ INPUTs: interrupção, cíclica, em horário definido...
 
       if (type == "INPUT" || type == "INPUT_ANALOG")
       {
         setIO[ref]["pin"] = pin;
-        setIO[ref]["Mode"] = type;
+        setIO[ref]["type"] = type;
+        setIO[ref]["mode"] = mode;
         pinMode(pin, INPUT);
+
+        if (mode == "interrupt")
+        {
+          interrupt_data* arg = new interrupt_data();
+          arg->remoteio_pointer = this;
+          arg->ref_arg = document["gpio"][i]["ref"].as<String>();
+          attachInterruptArg(digitalPinToInterrupt(pin), interruptCallback, (void*)arg, CHANGE);
+        }
       }
       else if (type == "INPUT_PULLUP")
       {
         setIO[ref]["pin"] = pin;
-        setIO[ref]["Mode"] = type;
+        setIO[ref]["type"] = type;
+        setIO[ref]["mode"] = mode;
         pinMode(pin, INPUT_PULLUP);
+
+        if (mode == "interrupt")
+        {
+          interrupt_data* arg = new interrupt_data();
+          arg->remoteio_pointer = this;
+          arg->ref_arg = document["gpio"][i]["ref"].as<String>();
+          attachInterruptArg(digitalPinToInterrupt(pin), interruptCallback, (void*)arg, CHANGE);
+        }
       }
       else if (type == "INPUT_PULLDOWN")
       {
         setIO[ref]["pin"] = pin;
-        setIO[ref]["Mode"] = type;
+        setIO[ref]["type"] = type;
+        setIO[ref]["mode"] = mode;
         pinMode(pin, INPUT_PULLDOWN);
+
+        if (mode == "interrupt")
+        {
+          interrupt_data* arg = new interrupt_data();
+          arg->remoteio_pointer = this;
+          arg->ref_arg = document["gpio"][i]["ref"].as<String>();
+          attachInterruptArg(digitalPinToInterrupt(pin), interruptCallback, (void*)arg, CHANGE);
+        }
       }
       else if (type == "OUTPUT")
       {
         setIO[ref]["pin"] = pin;
-        setIO[ref]["Mode"] = type;
+        setIO[ref]["type"] = type;
         pinMode(pin, OUTPUT);
       } 
       else 
@@ -981,6 +1044,16 @@ void RemoteIO::notFound(AsyncWebServerRequest *request)
   request->send(404, "application/json", "{\"message\":\"Not found\"}");
 }
 
+int RemoteIO::espPOST(JsonDocument arrayDoc)
+{
+  JsonDocument doc;
+  String value;
+  doc["deviceId"] = _deviceId;
+  doc["dataArray"] = arrayDoc;
+  serializeJson(doc, value);
+  return espPOST("appPostDataArray", "", value);
+}
+
 int RemoteIO::espPOST(String variable, String value)
 {
     return espPOST(appPostData, variable, value);
@@ -1018,8 +1091,8 @@ int RemoteIO::espPOST(String Router, String variable, String value)
     https.addHeader("Content-Type", "application/json");
     https.addHeader("authorization", "Bearer " + token);
 
-    //Serial.print("[espPOST] Request: ");
-    //Serial.println(request);
+    Serial.print("[espPOST] Request: ");
+    Serial.println(request);
     
     int httpCode = https.POST(request);
 

--- a/src/ESP32RemoteIO.h
+++ b/src/ESP32RemoteIO.h
@@ -50,9 +50,11 @@ class RemoteIO
   private:
     void notFound(AsyncWebServerRequest *request);
     void localHttpUpdateMsg(String ref, String value);
+    static void IRAM_ATTR interruptCallback(void* arg);
     void tryAuthenticate();    
     void fetchLatestData();
     void browseService(const char * service, const char * proto);
+    void sendDataFromQueue();
     void switchState();
     void stateLogic();
     void socketIOConnect();
@@ -61,6 +63,7 @@ class RemoteIO
     void extractIPAddress(String url);
     void startAccessPoint();
     void checkResetting(long timeInterval);
+    int espPOST(JsonDocument arrayDoc);
     int espPOST(String Router, String variable, String value);
 
     StaticJsonDocument<JSON_DOCUMENT_CAPACITY> configurationDocument;


### PR DESCRIPTION
Configuração do modo interrupção para leitura de inputs. Uma função de callback é executada para tratar a interrupção, que ocorre sempre que há uma mudança de estado no pino.

Neste instante é realizada uma leitura do estado do pino, cujo valor é adicionado a um objeto json juntamente com o timestamp da leitura e a referência associada.

O objeto criado para essa atualização de dados é adicionado a um json array, que poderá conter até 10 leituras diferentes. O envio das informações é feito no loop principal, sempre que houver pelo menos 1 objeto no array para ser enviado.
