### PR TITLE
Correção de parâmetros

### DIFF
--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -224,7 +224,7 @@ void RemoteIO::begin()
         String ref = data["ref"].as<String>();
         setIO[ref]["value"] = data["value"];
         
-        if (setIO[ref]["Mode"] == "OUTPUT")
+        if (setIO[ref]["type"] == "OUTPUT")
         {
           updatePinOutput(ref);
         }
@@ -684,7 +684,7 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
 
       setIO[ref]["value"] = value;
 
-      if (setIO[ref]["Mode"] == "OUTPUT")
+      if (setIO[ref]["type"] == "OUTPUT")
       {
         updatePinOutput(ref);
       }
@@ -925,7 +925,7 @@ void RemoteIO::tryAuthenticate()
       else 
       {
         setIO[ref]["pin"] = pin;
-        setIO[ref]["Mode"] = "N/L";
+        setIO[ref]["type"] = "N/L";
       }
     }
   }
@@ -965,7 +965,7 @@ void RemoteIO::fetchLatestData()
       
       setIO[auxRef]["value"] = auxValue;
       
-      if (setIO[auxRef]["Mode"] == "OUTPUT")
+      if (setIO[auxRef]["type"] == "OUTPUT")
       {
         updatePinOutput(auxRef);
       }
@@ -1008,7 +1008,7 @@ void RemoteIO::updatePinOutput(String ref)
 void RemoteIO::updatePinInput(String ref)
 {
   int pinRef = setIO[ref]["pin"].as<int>();
-  String typeRef = setIO[ref]["Mode"].as<String>();
+  String typeRef = setIO[ref]["type"].as<String>();
   int delayTime = setIO[ref]["delay"].as<int>() * 1000; // variável de configuração sincronizada com a plataforma
   int timestamp = setIO[ref]["timestamp"].as<int>();  // variável de configuração local, dessincronizada
 


### PR DESCRIPTION
Correção de parâmetros de configuração de IOs do dispositivo, definidos no JsonObject setIO após a autenticação.

Na mensagem json recebida da plataforma após a autenticação, a configuração do pino (INPUT/OUTPUT/etc) é chamada de "type". Porém, no documento setIO que armazena essas informações, a configuração do pino estava sendo registrada como "Mode".

Alterei o nome dessa configuração no setIO para "type", com o intuito de utilizar "mode" para outro propósito. 