### PR TITLE
Adição de hyperlink no banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![nodeiot Banner](https://user-utilities.s3.amazonaws.com/assets/Documenta%C3%A7%C3%A3o/banner_repositorio.jpg)
+<p align="center">
+  <a href="https://nodeiot.com.br/"><img alt="NodeIoT" src="https://user-utilities.s3.amazonaws.com/assets/Documenta%C3%A7%C3%A3o/banner_repositorio.jpg" /></a>
+</p>
 
 # ESP32RemoteIO
 


### PR DESCRIPTION
Pequena alteração no README.md para adicionar um hyperlink no banner, levando ao site da NodeIoT.