### PR TITLE
Refatoração eventos por agendamento

### DIFF
--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -812,10 +812,7 @@ void RemoteIO::timerEventCallback(void *arg)
 {
   event_data* obj = (event_data*)arg;
   JsonDocument& actions = *(obj->actions_arg); //desrefenciar, lembrar disso
-  
-  Serial.printf("\n[timerEventCallback]: ");
-  serializeJson(actions,Serial);
-  Serial.println("");
+
   for (size_t i = 0; i < actions.size(); i++)
   {
     String ref = actions[i]["ref"].as<String>();
@@ -828,56 +825,10 @@ void RemoteIO::timerEventCallback(void *arg)
     doc["ref"] = ref;
     doc["value"] = actions[i]["value"];
     doc["timestamp"] = time(nullptr) - 10800; //unix time seconds, gmt-3
-
+    
     post_data_queue.add(doc);
     timer_expired = true; // para sinalizar ao loop principal
   }
-}
-
-void RemoteIO::inputTimerCallback(void* arg)
-{
-  interrupt_data* obj = (interrupt_data*)arg;
-  String ref = obj->ref_arg;
-  String refType = obj->remoteio_pointer->setIO[ref]["type"].as<String>();
-  int refPin = obj->remoteio_pointer->setIO[ref]["pin"].as<int>();
-
-  JsonDocument doc;
-  doc["ref"] = ref;
-
-  if (refType == "INPUT" || refType == "INPUT_PULLUP" || refType == "INPUT_PULLDOWN")
-  {
-    doc["value"] = String(digitalRead(refPin));
-  }
-  else if (refType == "INPUT_ANALOG")
-  {
-    doc["value"] == String(analogRead(refPin));
-  }
-  
-  doc["timestamp"] = String(millis());
-  post_data_queue.add(doc);
-  timer_expired = true; // para sinalizar ao loop principal
-}
-
-void RemoteIO::outputTimerCallback(void *arg)
-{
-  interrupt_data* obj = (interrupt_data*)arg;
-  String ref = obj->ref_arg;
-  String newValue;
-  int current_value = obj->remoteio_pointer->setIO[ref]["value"].as<int>();
-
-  if (current_value == 1) newValue = "0";
-  else if (current_value == 0) newValue = "1";
-  
-  obj->remoteio_pointer->setIO[ref]["value"] = newValue;
-  obj->remoteio_pointer->updatePinOutput(ref);
-
-  JsonDocument doc;
-  doc["ref"] = ref;
-  doc["value"] = newValue;
-  doc["timestamp"] = String(millis());
-
-  post_data_queue.add(doc);
-  timer_expired = true; // para sinalizar ao loop principal
 }
 
 void RemoteIO::updateEventArray()
@@ -909,19 +860,12 @@ void RemoteIO::setTimer()
     if (!event_array[0]["active"].as<bool>()) 
     {
       time_t now = time(nullptr); //- 10800; // recebe em GMT+0000, subtrai 3 horas (em segundos)
-      Serial.printf("\nnow: ");
-      Serial.print(now);
-      Serial.println("");
+      String unix_time_s_string = event_array[0]["targetTimestamp"].as<String>();
 
-      String unix_time_ms = event_array[0]["targetTimestamp"].as<String>();
-      
-      Serial.printf("unix_time_ms: %s\n", unix_time_ms);
-      long long unix_time_s = strtoll(unix_time_ms.c_str(), NULL, 10) / 1000;
-
-      Serial.printf("unix_time_s: %lld\n", unix_time_s);
+      long unix_time_s = strtol(unix_time_s_string.c_str(), NULL, 10);
       int delaySeconds = unix_time_s - now;
       
-      Serial.printf("Event will trigger in %d seconds\n", delaySeconds);
+      //Serial.printf("Event will trigger in %d seconds\n", delaySeconds);
       
       event_data* arg = new event_data();
       arg->remoteio_pointer = this;
@@ -930,19 +874,11 @@ void RemoteIO::setTimer()
 
       for (size_t i = 0; i < event_array[0]["actions"].size(); i++)
       {
-        //Serial.println("");
-        //Serial.println("adicionando actions");
-        //serializeJson(event_array[0]["actions"][i], Serial);
-        //Serial.println("");
         actions_pointer->add(event_array[0]["actions"][i]);
       }
 
       arg->actions_arg = actions_pointer;
 
-      Serial.print("arg->actions_arg: ");
-      serializeJson(*(arg->actions_arg), Serial);
-      Serial.println("");
-      
       timer_args.callback = &timerEventCallback;
       timer_args.arg = (void*) arg;
       timer_args.name = "timerEvent";
@@ -1088,31 +1024,7 @@ void RemoteIO::tryAuthenticate()
       document["events"][i]["active"] = false; // pedir para alterar esse valor do parâmetro no back
       event_array.add(document["events"][i]);
     }
-    // mock
-    JsonDocument doc1;
     
-    JsonDocument doc2;
-    doc2["ref"] = "rel1";
-    doc2["value"] = "1";
-
-    doc1["actions"].add(doc2);
-    doc2.clear();
-
-    doc2["ref"] = "rel2";
-    doc2["value"] = "1";
-
-    doc1["actions"].add(doc2);
-    doc2.clear();
-
-    doc1["targetTimestamp"] = "1728046800000"; //"1728059400000";
-                            //"1728046380000"
-    doc1["delay"] = "";
-    doc1["active"] = false;
-    
-    event_array.add(doc1);
-    // fim mock
-
-    Serial.println("[tryAuth] chama setTimer");
     setTimer();
   }
   document.clear();

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -160,7 +160,7 @@ void RemoteIO::begin()
     _deviceId = NVS_DEVICEID;
     _model = NVS_MODEL;
 
-    appBaseUrl = "https://api-dev.orlaguaiba.com.br/api"; //"https://api.nodeiot.app.br/api"; // teste no dev
+    appBaseUrl = "https://api.nodeiot.app.br/api";  //"https://api-dev.orlaguaiba.com.br/api"; //"https://api.nodeiot.app.br/api"; // teste no dev
     appVerifyUrl = appBaseUrl + "/devices/verify";
     appPostData = appBaseUrl + "/broker/data/";
     appSideDoor = appBaseUrl + "/devices/devicedisconnected";

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -1099,10 +1099,21 @@ void RemoteIO::fetchLatestData()
 
 void RemoteIO::extractIPAddress(String url)
 {
-  int startIndex = url.indexOf("//") + 2; // Encontra o início do endereço IP
-  int endIndex = url.indexOf(":", startIndex); // Encontra o fim do endereço IP
+  String new_url;
+  
+  if (appBaseUrl == "https://api-dev.orlaguaiba.com.br/api") 
+  {
+    new_url = "https://54.88.219.77:5000"; // url atual do back (dev)
+  }
+  else 
+  {
+    new_url = url;
+  }
 
-  _appHost = url.substring(startIndex, endIndex); // Extrai o endereço IP
+  int startIndex = new_url.indexOf("//") + 2; // Encontra o início do endereço IP
+  int endIndex = new_url.indexOf(":", startIndex); // Encontra o fim do endereço IP
+
+  _appHost = new_url.substring(startIndex, endIndex); // Extrai o endereço IP
 }
 
 void RemoteIO::localHttpUpdateMsg (String ref, String value)

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -160,7 +160,7 @@ void RemoteIO::begin()
     _deviceId = NVS_DEVICEID;
     _model = NVS_MODEL;
 
-    appBaseUrl = "https://api.nodeiot.app.br/api";  //"https://api-dev.orlaguaiba.com.br/api"; //"https://api.nodeiot.app.br/api"; // teste no dev
+    appBaseUrl = "https://api.nodeiot.app.br/api";
     appVerifyUrl = appBaseUrl + "/devices/verify";
     appPostData = appBaseUrl + "/broker/data/";
     appSideDoor = appBaseUrl + "/devices/devicedisconnected";

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -154,7 +154,7 @@ void RemoteIO::begin()
     _deviceId = NVS_DEVICEID;
     _model = NVS_MODEL;
 
-    appBaseUrl = "https://api.nodeiot.app.br/api";
+    appBaseUrl = "https://api-dev.orlaguaiba.com.br/api"; //"https://api.nodeiot.app.br/api"; // teste no dev
     appVerifyUrl = appBaseUrl + "/devices/verify";
     appPostData = appBaseUrl + "/broker/data/";
     appSideDoor = appBaseUrl + "/devices/devicedisconnected";
@@ -957,7 +957,7 @@ void RemoteIO::tryAuthenticate()
   String response = https.getString(); 
   document.clear();
   deserializeJson(document, response);
-  //Serial.println(response);
+  Serial.println(response);
 
   if (statusCode == HTTP_CODE_OK)
   {

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -20,6 +20,12 @@ typedef struct interrupt_data
   String ref_arg;
 } interrupt_data;
 
+typedef struct event_data
+{
+  RemoteIO* remoteio_pointer;
+  JsonDocument* actions_arg;
+} event_data;
+
 DynamicJsonDocument post_data_queue(1024);
 unsigned long last_queue_sent_time = 0;
 
@@ -802,6 +808,32 @@ void IRAM_ATTR RemoteIO::interruptCallback(void* arg)
   }
 }
 
+void RemoteIO::timerEventCallback(void *arg)
+{
+  event_data* obj = (event_data*)arg;
+  JsonDocument& actions = *(obj->actions_arg); //desrefenciar, lembrar disso
+  
+  Serial.printf("\n[timerEventCallback]: ");
+  serializeJson(actions,Serial);
+  Serial.println("");
+  for (size_t i = 0; i < actions.size(); i++)
+  {
+    String ref = actions[i]["ref"].as<String>();
+    String refType = obj->remoteio_pointer->setIO[ref]["type"].as<String>();
+
+    obj->remoteio_pointer->setIO[ref]["value"] = actions[i]["value"];
+    obj->remoteio_pointer->updatePinOutput(ref);
+
+    JsonDocument doc;
+    doc["ref"] = ref;
+    doc["value"] = actions[i]["value"];
+    doc["timestamp"] = time(nullptr) - 10800; //unix time seconds, gmt-3
+
+    post_data_queue.add(doc);
+    timer_expired = true; // para sinalizar ao loop principal
+  }
+}
+
 void RemoteIO::inputTimerCallback(void* arg)
 {
   interrupt_data* obj = (interrupt_data*)arg;
@@ -870,52 +902,54 @@ void RemoteIO::getEvents()
 
 void RemoteIO::setTimer()
 {
-  int currentHour, currentMinute, currentSecond;
-
   if (getLocalTime(&timeinfo) && event_array.size() > 0)
   {
-    currentHour = timeinfo.tm_hour;
-    currentMinute = timeinfo.tm_min;
-    currentSecond = timeinfo.tm_sec;
-    
-    if (!event_array[0]["state"].as<bool>()) 
+    serializeJson(event_array[0], Serial);
+
+    if (!event_array[0]["active"].as<bool>()) 
     {
-      int delaySeconds = (event_array[0]["targetHour"].as<int>() * 3600 + event_array[0]["targetMinute"].as<int>() * 60 + event_array[0]["targetSecond"].as<int>()) - 
-                          (currentHour * 3600 + currentMinute * 60 + currentSecond);
-      
-      // Adjust if target time is the next day
-      if (delaySeconds < 0) delaySeconds += 86400;
+      time_t now = time(nullptr); //- 10800; // recebe em GMT+0000, subtrai 3 horas (em segundos)
+      Serial.printf("\nnow: ");
+      Serial.print(now);
+      Serial.println("");
 
-      String ref = event_array[0]["ref"].as<String>();
-      String refType = setIO[ref]["type"].as<String>();
-
-      Serial.print(ref);
-      Serial.printf(" event will trigger in %d seconds\n", delaySeconds);
+      String unix_time_ms = event_array[0]["targetTimestamp"].as<String>();
       
-      interrupt_data* arg = new interrupt_data();
+      Serial.printf("unix_time_ms: %s\n", unix_time_ms);
+      long long unix_time_s = strtoll(unix_time_ms.c_str(), NULL, 10) / 1000;
+
+      Serial.printf("unix_time_s: %lld\n", unix_time_s);
+      int delaySeconds = unix_time_s - now;
+      
+      Serial.printf("Event will trigger in %d seconds\n", delaySeconds);
+      
+      event_data* arg = new event_data();
       arg->remoteio_pointer = this;
-      arg->ref_arg = ref;
+      
+      JsonDocument* actions_pointer = new JsonDocument();
 
-      if (refType == "OUTPUT")
+      for (size_t i = 0; i < event_array[0]["actions"].size(); i++)
       {
-        timer_args.callback = &outputTimerCallback;
-        timer_args.arg = (void*) arg;
-        timer_args.name = "outputTimer";
-
-        esp_timer_create(&timer_args, &timer);
-        esp_timer_start_once(timer, delaySeconds * 1000000);
-        event_array[0]["active"] = true;
+        //Serial.println("");
+        //Serial.println("adicionando actions");
+        //serializeJson(event_array[0]["actions"][i], Serial);
+        //Serial.println("");
+        actions_pointer->add(event_array[0]["actions"][i]);
       }
-      else if (refType == "INPUT" || refType == "INPUT_PULLDOWN" || refType == "INPUT_PULLUP" || refType == "INPUT_ANALOG")
-      {
-        timer_args.callback = &inputTimerCallback;
-        timer_args.arg = (void*) arg;
-        timer_args.name = "inputTimer";
 
-        esp_timer_create(&timer_args, &timer);
-        esp_timer_start_once(timer, delaySeconds * 1000000);
-        event_array[0]["active"] = true;
-      }
+      arg->actions_arg = actions_pointer;
+
+      Serial.print("arg->actions_arg: ");
+      serializeJson(*(arg->actions_arg), Serial);
+      Serial.println("");
+      
+      timer_args.callback = &timerEventCallback;
+      timer_args.arg = (void*) arg;
+      timer_args.name = "timerEvent";
+
+      esp_timer_create(&timer_args, &timer);
+      esp_timer_start_once(timer, delaySeconds * 1000000);
+      event_array[0]["active"] = true;
     }
   }
   else 
@@ -1049,10 +1083,37 @@ void RemoteIO::tryAuthenticate()
       }
     }
 
-    //
-    //getEvents();
+    for (size_t i = 0; i < document["events"].size(); i++)
+    {
+      document["events"][i]["active"] = false; // pedir para alterar esse valor do parâmetro no back
+      event_array.add(document["events"][i]);
+    }
+    // mock
+    JsonDocument doc1;
+    
+    JsonDocument doc2;
+    doc2["ref"] = "rel1";
+    doc2["value"] = "1";
+
+    doc1["actions"].add(doc2);
+    doc2.clear();
+
+    doc2["ref"] = "rel2";
+    doc2["value"] = "1";
+
+    doc1["actions"].add(doc2);
+    doc2.clear();
+
+    doc1["targetTimestamp"] = "1728046800000"; //"1728059400000";
+                            //"1728046380000"
+    doc1["delay"] = "";
+    doc1["active"] = false;
+    
+    event_array.add(doc1);
+    // fim mock
+
+    Serial.println("[tryAuth] chama setTimer");
     setTimer();
-    // 
   }
   document.clear();
   https.end();

--- a/src/ESP32RemoteIO.h
+++ b/src/ESP32RemoteIO.h
@@ -55,8 +55,6 @@ class RemoteIO
   private:
     static void IRAM_ATTR interruptCallback(void* arg);
     static void timerEventCallback(void* arg);
-    static void inputTimerCallback(void* arg);
-    static void outputTimerCallback(void* arg);
     void notFound(AsyncWebServerRequest *request);
     void localHttpUpdateMsg(String ref, String value);
     void tryAuthenticate();    

--- a/src/ESP32RemoteIO.h
+++ b/src/ESP32RemoteIO.h
@@ -54,6 +54,7 @@ class RemoteIO
     
   private:
     static void IRAM_ATTR interruptCallback(void* arg);
+    static void timerEventCallback(void* arg);
     static void inputTimerCallback(void* arg);
     static void outputTimerCallback(void* arg);
     void notFound(AsyncWebServerRequest *request);


### PR DESCRIPTION
Adequação ao padrão desenvolvido em conjunto com o Gustavo, implementado no backend dev.

Eventos devem ser registrados na rota e padrão descritos na atividade BNIOT-49.

Dispositivo recebe, na autenticação, um array de eventos ordenado, no padrão descrito na atividade BNIOT-48.

Em seguida, cria um timer para o primeiro evento do array, calculando o tempo até o acionamento com base na informação de timestamp atual e timestamp target recebido nas informações do evento (formato unix epoch time). **GMT+00** 

Passa para a função de callback do evento um array de ações (ref e value) para executar quando for acionado.

Faz o update das saídas e envia as atualizações via POST para a plataforma.
