### PR TITLE
Evento socket infoUpdated

### DIFF
--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -661,6 +661,13 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
       
       String eventName = doc[0];
 
+      Serial.printf("\n[socketIOEvent] eventName: %s\n", eventName);
+
+      if (eventName == "infoUpdated")
+      {
+        // tratar refs de funções padrão (reset, disconnect, etc...)
+      }
+
       if (doc[1].containsKey("ipdest")) // modo âncora
       {
         StaticJsonDocument<250> doc2;

--- a/src/ESP32RemoteIO.cpp
+++ b/src/ESP32RemoteIO.cpp
@@ -633,6 +633,36 @@ void RemoteIO::stateLogic()
   }
 }
 
+int RemoteIO::updateFirmwareOTA()
+{
+  int ret = ota.CheckForOTAUpdate(OTA_JSON_URL, "0.0.0");
+  return ret;
+}
+
+void RemoteIO::rebootDevice()
+{
+  ESP.restart();
+}
+
+void RemoteIO::eraseDeviceSettings()
+{
+  deviceConfig->begin("deviceConfig", false);
+  deviceConfig->clear();
+  deviceConfig->end();
+  Serial.printf("\nApagando configurações salvas na memória não volátil...\n");
+  delay(1000);
+  ESP.restart();
+}
+
+void RemoteIO::infoUpdatedEventHandler(JsonDocument payload_doc)
+{
+  String ref = payload_doc[1]["ref"];
+  
+  if (ref == "restart") rebootDevice();
+  else if (ref == "reset") eraseDeviceSettings();
+  else if (ref == "otaUpdate") updateFirmwareOTA();
+}
+
 void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_t length)
 {
   switch (type)
@@ -661,11 +691,9 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
       
       String eventName = doc[0];
 
-      Serial.printf("\n[socketIOEvent] eventName: %s\n", eventName);
-
       if (eventName == "infoUpdated")
       {
-        // tratar refs de funções padrão (reset, disconnect, etc...)
+        infoUpdatedEventHandler(doc);
       }
 
       if (doc[1].containsKey("ipdest")) // modo âncora
@@ -687,19 +715,7 @@ void RemoteIO::socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_
         String ref = doc[1]["ref"];
         String value = doc[1]["value"];
 
-        if (ref == "restart") ESP.restart();
-        else if (ref == "reset")
-        {
-          deviceConfig->begin("deviceConfig", false);
-          deviceConfig->clear();
-          deviceConfig->end();
-          delay(1000);
-          ESP.restart();
-        }
-        else if (ref == "otaUpdate")
-        {
-          int ret = ota.CheckForOTAUpdate(OTA_JSON_URL, "0.0.0");
-        }
+        infoUpdatedEventHandler(doc);
 
         setIO[ref]["value"] = value;
 

--- a/src/ESP32RemoteIO.h
+++ b/src/ESP32RemoteIO.h
@@ -66,6 +66,10 @@ class RemoteIO
     void socketIOConnect();
     void nodeIotConnection(void (*userCallbackFunction)(String ref, String value));
     void socketIOEvent(socketIOmessageType_t type, uint8_t *payload, size_t length);
+    int updateFirmwareOTA();
+    void rebootDevice();
+    void eraseDeviceSettings();
+    void infoUpdatedEventHandler(JsonDocument payload_doc);
     void extractIPAddress(String url);
     void startAccessPoint();
     void checkResetting(long timeInterval);


### PR DESCRIPTION
Como solicitado na atividade ENIOT-164, as ações de gerenciamento (reboot, reset e otaUpdate) padronizadas no dispositivo foram passadas para um outro tipo de evento de comunicação (infoUpdated). Até então estavam sendo tratadas como eventos do tipo dataUpdate. 

Foi criada a função **infoUpdatedEventHandler** para tratar toda a comunicação recebida pelo **eventName "infoUpdated"**, onde verifica-se a ação solicitada (restart/reset/otaUpdate) e faz-se a chamada da respectiva função auxiliar que realiza esta ação. (**rebootDevice/eraseDeviceSettings/updateFirmwareOTA**).