### PR TITLE
Alteração no html de credenciais para permitir envio sem deviceId

### DIFF
--- a/src/index_html.h
+++ b/src/index_html.h
@@ -165,7 +165,7 @@ const char page_setup[] PROGMEM = R"rawliteral(
                     <label for="companyName">Nome da empresa:</label>
                     <input type="text" id="companyName" name="companyName" required>
                     <label for="deviceId">Nome do dispositivo:</label>
-                    <input type="text" id="deviceId" name="deviceId" required>
+                    <input type="text" id="deviceId" name="deviceId">
 
                     <div class="SubmitButton">
                         <input type="submit" id="submitButton" value="Salvar">


### PR DESCRIPTION
Para possibilitar o fluxo de auto-registro de dispositivo, removi a obrigatoriedade do campo deviceId ao utilizar o endpoint e página html usados para inserir as credenciais de rede wi-fi e conta nodeiot.